### PR TITLE
Ignore CMake-generated build files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,8 @@ Temporary Items
 *.icloud
 
 # End of https://www.toptal.com/developers/gitignore/api/c++,cuda,cmake,c,macos
+
+### CMake-generated build files ###
+# When using CMake, the build output is typically placed in a separate directory called "build".
+# It's common practice to exclude this directory from version control to avoid unnecessary tracking of generated files.
+build/


### PR DESCRIPTION
When using _CMake_, the build output is typically placed in a separate directory called `build/`.
It's common practice to exclude this directory from version control to avoid unnecessary tracking of generated files.

While individual files like `cmake_install.cmake`, `CMakeFiles`, and `CMakeCache.txt` were previously ignored, opting to exclude the entire build directory directly ensures that all generated files within `build/` are not tracked by version control, particularly the targets `inOneWeekend`, `theNextWeek`, and `theRestOfYourLife`.