### PR TITLE
Fix the overhead of `rand` function and Remove min reduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ Temporary Items
 # When using CMake, the build output is typically placed in a separate directory called "build".
 # It's common practice to exclude this directory from version control to avoid unnecessary tracking of generated files.
 build/
+*.data
+*.data.old

--- a/openmp/include/InOneWeekend/hittable.h
+++ b/openmp/include/InOneWeekend/hittable.h
@@ -35,7 +35,7 @@ class hittable
 {
    public:
     virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec,
-                     unsigned int* seed) const = 0;
+                     unsigned int& seed) const = 0;
 };
 
 #endif

--- a/openmp/include/InOneWeekend/hittable.h
+++ b/openmp/include/InOneWeekend/hittable.h
@@ -35,7 +35,7 @@ class hittable
 {
    public:
     virtual bool hit(const ray& r, double t_min, double t_max,
-                     hit_record& rec) const = 0;
+                     hit_record& rec, unsigned int* seed) const = 0;
 };
 
 #endif

--- a/openmp/include/InOneWeekend/hittable.h
+++ b/openmp/include/InOneWeekend/hittable.h
@@ -34,8 +34,8 @@ struct hit_record
 class hittable
 {
    public:
-    virtual bool hit(const ray& r, double t_min, double t_max,
-                     hit_record& rec, unsigned int* seed) const = 0;
+    virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec,
+                     unsigned int* seed) const = 0;
 };
 
 #endif

--- a/openmp/include/InOneWeekend/hittable_list.h
+++ b/openmp/include/InOneWeekend/hittable_list.h
@@ -30,14 +30,14 @@ class hittable_list : public hittable
     void add(shared_ptr<hittable> object) { objects.push_back(object); }
 
     virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec,
-                     unsigned int* seed) const override;
+                     unsigned int& seed) const override;
 
    public:
     std::vector<shared_ptr<hittable>> objects;
 };
 
 bool hittable_list::hit(const ray& r, double t_min, double t_max,
-                        hit_record& rec, unsigned int* seed) const
+                        hit_record& rec, unsigned int& seed) const
 {
     hit_record temp_rec;
     auto hit_anything = false;

--- a/openmp/include/InOneWeekend/hittable_list.h
+++ b/openmp/include/InOneWeekend/hittable_list.h
@@ -42,7 +42,7 @@ bool hittable_list::hit(const ray& r, double t_min, double t_max,
     hit_record temp_rec;
     auto hit_anything = false;
     auto closest_so_far = t_max;
-#pragma omp parallel for reduction(min : closest_so_far)
+    // #pragma omp parallel for reduction(min : closest_so_far)
     for (int i = 0; i < objects.size(); ++i)
     {
         const auto& object = objects[i];

--- a/openmp/include/InOneWeekend/hittable_list.h
+++ b/openmp/include/InOneWeekend/hittable_list.h
@@ -30,14 +30,14 @@ class hittable_list : public hittable
     void add(shared_ptr<hittable> object) { objects.push_back(object); }
 
     virtual bool hit(const ray& r, double t_min, double t_max,
-                     hit_record& rec) const override;
+                     hit_record& rec, unsigned int* seed) const override;
 
    public:
     std::vector<shared_ptr<hittable>> objects;
 };
 
 bool hittable_list::hit(const ray& r, double t_min, double t_max,
-                        hit_record& rec) const
+                        hit_record& rec, unsigned int* seed) const
 {
     hit_record temp_rec;
     auto hit_anything = false;
@@ -46,7 +46,7 @@ bool hittable_list::hit(const ray& r, double t_min, double t_max,
     for (int i = 0; i < objects.size(); ++i)
     {
         const auto& object = objects[i];
-        if (object->hit(r, t_min, closest_so_far, temp_rec))
+        if (object->hit(r, t_min, closest_so_far, temp_rec, seed))
         {
             hit_anything = true;
             closest_so_far = temp_rec.t;

--- a/openmp/include/InOneWeekend/hittable_list.h
+++ b/openmp/include/InOneWeekend/hittable_list.h
@@ -29,8 +29,8 @@ class hittable_list : public hittable
     void clear() { objects.clear(); }
     void add(shared_ptr<hittable> object) { objects.push_back(object); }
 
-    virtual bool hit(const ray& r, double t_min, double t_max,
-                     hit_record& rec, unsigned int* seed) const override;
+    virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec,
+                     unsigned int* seed) const override;
 
    public:
     std::vector<shared_ptr<hittable>> objects;

--- a/openmp/include/InOneWeekend/material.h
+++ b/openmp/include/InOneWeekend/material.h
@@ -88,7 +88,7 @@ class dielectric : public material
         vec3 direction;
 
         if (cannot_refract ||
-            reflectance(cos_theta, refraction_ratio) > random_double_r(&seed))
+            reflectance(cos_theta, refraction_ratio) > random_double_r(seed))
             direction = reflect(unit_direction, rec.normal);
         else
             direction = refract(unit_direction, rec.normal, refraction_ratio);

--- a/openmp/include/InOneWeekend/material.h
+++ b/openmp/include/InOneWeekend/material.h
@@ -20,7 +20,8 @@ class material
 {
    public:
     virtual bool scatter(const ray& r_in, const hit_record& rec,
-                         color& attenuation, ray& scattered) const = 0;
+                         color& attenuation, ray& scattered,
+                         unsigned int& seed) const = 0;
 };
 
 class lambertian : public material
@@ -29,9 +30,10 @@ class lambertian : public material
     lambertian(const color& a) : albedo(a) {}
 
     virtual bool scatter(const ray& r_in, const hit_record& rec,
-                         color& attenuation, ray& scattered) const override
+                         color& attenuation, ray& scattered,
+                         unsigned int& seed) const override
     {
-        auto scatter_direction = rec.normal + random_unit_vector();
+        auto scatter_direction = rec.normal + random_unit_vector_r(seed);
 
         // Catch degenerate scatter direction
         if (scatter_direction.near_zero()) scatter_direction = rec.normal;
@@ -51,10 +53,12 @@ class metal : public material
     metal(const color& a, double f) : albedo(a), fuzz(f < 1 ? f : 1) {}
 
     virtual bool scatter(const ray& r_in, const hit_record& rec,
-                         color& attenuation, ray& scattered) const override
+                         color& attenuation, ray& scattered,
+                         unsigned int& seed) const override
     {
         vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
-        scattered = ray(rec.p, reflected + fuzz * random_in_unit_sphere());
+        scattered =
+            ray(rec.p, reflected + fuzz * random_in_unit_sphere_r(seed));
         attenuation = albedo;
         return (dot(scattered.direction(), rec.normal) > 0);
     }
@@ -70,7 +74,8 @@ class dielectric : public material
     dielectric(double index_of_refraction) : ir(index_of_refraction) {}
 
     virtual bool scatter(const ray& r_in, const hit_record& rec,
-                         color& attenuation, ray& scattered) const override
+                         color& attenuation, ray& scattered,
+                         unsigned int& seed) const override
     {
         attenuation = color(1.0, 1.0, 1.0);
         double refraction_ratio = rec.front_face ? (1.0 / ir) : ir;
@@ -83,7 +88,7 @@ class dielectric : public material
         vec3 direction;
 
         if (cannot_refract ||
-            reflectance(cos_theta, refraction_ratio) > random_double())
+            reflectance(cos_theta, refraction_ratio) > random_double_r(&seed))
             direction = reflect(unit_direction, rec.normal);
         else
             direction = refract(unit_direction, rec.normal, refraction_ratio);

--- a/openmp/include/InOneWeekend/sphere.h
+++ b/openmp/include/InOneWeekend/sphere.h
@@ -23,8 +23,8 @@ class sphere : public hittable
     sphere(point3 cen, double r, shared_ptr<material> m)
         : center(cen), radius(r), mat_ptr(m){};
 
-    virtual bool hit(const ray& r, double t_min, double t_max,
-                     hit_record& rec, unsigned int* seed) const override;
+    virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec,
+                     unsigned int* seed) const override;
 
    public:
     point3 center;
@@ -32,8 +32,8 @@ class sphere : public hittable
     shared_ptr<material> mat_ptr;
 };
 
-bool sphere::hit(const ray& r, double t_min, double t_max,
-                 hit_record& rec, unsigned int* seed) const
+bool sphere::hit(const ray& r, double t_min, double t_max, hit_record& rec,
+                 unsigned int* seed) const
 {
     vec3 oc = r.origin() - center;
     auto a = r.direction().length_squared();

--- a/openmp/include/InOneWeekend/sphere.h
+++ b/openmp/include/InOneWeekend/sphere.h
@@ -24,7 +24,7 @@ class sphere : public hittable
         : center(cen), radius(r), mat_ptr(m){};
 
     virtual bool hit(const ray& r, double t_min, double t_max,
-                     hit_record& rec) const override;
+                     hit_record& rec, unsigned int* seed) const override;
 
    public:
     point3 center;
@@ -33,7 +33,7 @@ class sphere : public hittable
 };
 
 bool sphere::hit(const ray& r, double t_min, double t_max,
-                 hit_record& rec) const
+                 hit_record& rec, unsigned int* seed) const
 {
     vec3 oc = r.origin() - center;
     auto a = r.direction().length_squared();

--- a/openmp/include/InOneWeekend/sphere.h
+++ b/openmp/include/InOneWeekend/sphere.h
@@ -24,7 +24,7 @@ class sphere : public hittable
         : center(cen), radius(r), mat_ptr(m){};
 
     virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec,
-                     unsigned int* seed) const override;
+                     unsigned int& seed) const override;
 
    public:
     point3 center;
@@ -33,7 +33,7 @@ class sphere : public hittable
 };
 
 bool sphere::hit(const ray& r, double t_min, double t_max, hit_record& rec,
-                 unsigned int* seed) const
+                 unsigned int& seed) const
 {
     vec3 oc = r.origin() - center;
     auto a = r.direction().length_squared();

--- a/openmp/include/common/camera.h
+++ b/openmp/include/common/camera.h
@@ -57,6 +57,16 @@ class camera
             random_double(time0, time1));
     }
 
+    ray get_ray_r(double s, double t, unsigned int &seed) const
+    {
+        vec3 rd = lens_radius * random_in_unit_disk_r(seed);
+        vec3 offset = u * rd.x() + v * rd.y();
+        return ray(
+            origin + offset,
+            lower_left_corner + s * horizontal + t * vertical - origin - offset,
+            random_double_r(time0, time1, &seed));
+    }
+
    private:
     point3 origin;
     point3 lower_left_corner;

--- a/openmp/include/common/camera.h
+++ b/openmp/include/common/camera.h
@@ -64,7 +64,7 @@ class camera
         return ray(
             origin + offset,
             lower_left_corner + s * horizontal + t * vertical - origin - offset,
-            random_double_r(time0, time1, &seed));
+            random_double_r(time0, time1, seed));
     }
 
    private:

--- a/openmp/include/common/rtweekend.h
+++ b/openmp/include/common/rtweekend.h
@@ -46,16 +46,35 @@ inline double random_double()
     return rand() / (RAND_MAX + 1.0);
 }
 
+inline double random_double_r(unsigned int *seed)
+{
+    // Returns a random real in [0,1).
+    return rand_r(seed) / (RAND_MAX + 1.0);
+}
+
+
 inline double random_double(double min, double max)
 {
     // Returns a random real in [min,max).
     return min + (max - min) * random_double();
 }
 
+inline double random_double_r(double min, double max, unsigned int *seed)
+{
+    // Returns a random real in [min,max).
+    return min + (max - min) * random_double_r(seed);
+}
+
 inline int random_int(int min, int max)
 {
     // Returns a random integer in [min,max].
     return static_cast<int>(random_double(min, max + 1));
+}
+
+inline int random_int_r(int min, int max, unsigned int *seed)
+{
+    // Returns a random integer in [min,max].
+    return static_cast<int>(random_double_r(min, max + 1, seed));
 }
 
 // Common Headers

--- a/openmp/include/common/rtweekend.h
+++ b/openmp/include/common/rtweekend.h
@@ -52,7 +52,6 @@ inline double random_double_r(unsigned int *seed)
     return rand_r(seed) / (RAND_MAX + 1.0);
 }
 
-
 inline double random_double(double min, double max)
 {
     // Returns a random real in [min,max).

--- a/openmp/include/common/rtweekend.h
+++ b/openmp/include/common/rtweekend.h
@@ -46,10 +46,10 @@ inline double random_double()
     return rand() / (RAND_MAX + 1.0);
 }
 
-inline double random_double_r(unsigned int *seed)
+inline double random_double_r(unsigned int& seed)
 {
     // Returns a random real in [0,1).
-    return rand_r(seed) / (RAND_MAX + 1.0);
+    return rand_r(&seed) / (RAND_MAX + 1.0);
 }
 
 inline double random_double(double min, double max)
@@ -58,7 +58,7 @@ inline double random_double(double min, double max)
     return min + (max - min) * random_double();
 }
 
-inline double random_double_r(double min, double max, unsigned int *seed)
+inline double random_double_r(double min, double max, unsigned int& seed)
 {
     // Returns a random real in [min,max).
     return min + (max - min) * random_double_r(seed);
@@ -70,7 +70,7 @@ inline int random_int(int min, int max)
     return static_cast<int>(random_double(min, max + 1));
 }
 
-inline int random_int_r(int min, int max, unsigned int *seed)
+inline int random_int_r(int min, int max, unsigned int& seed)
 {
     // Returns a random integer in [min,max].
     return static_cast<int>(random_double_r(min, max + 1, seed));

--- a/openmp/include/common/vec3.h
+++ b/openmp/include/common/vec3.h
@@ -16,6 +16,7 @@
 #include <iostream>
 
 using std::fabs;
+using std::fmin;
 using std::sqrt;
 
 class vec3
@@ -73,6 +74,19 @@ class vec3
     {
         return vec3(random_double(min, max), random_double(min, max),
                     random_double(min, max));
+    }
+
+    inline static vec3 random_r(unsigned int &seed)
+    {
+        return vec3(random_double_r(&seed), random_double_r(&seed),
+                    random_double_r(&seed));
+    }
+
+    inline static vec3 random_r(double min, double max, unsigned int &seed)
+    {
+        return vec3(random_double_r(min, max, &seed),
+                    random_double_r(min, max, &seed),
+                    random_double_r(min, max, &seed));
     }
 
    public:
@@ -138,6 +152,17 @@ inline vec3 random_in_unit_disk()
     }
 }
 
+inline vec3 random_in_unit_disk_r(unsigned int &seed)
+{
+    while (true)
+    {
+        auto p = vec3(random_double_r(-1, 1, &seed),
+                      random_double_r(-1, 1, &seed), 0);
+        if (p.length_squared() >= 1) continue;
+        return p;
+    }
+}
+
 inline vec3 random_in_unit_sphere()
 {
     while (true)
@@ -148,14 +173,39 @@ inline vec3 random_in_unit_sphere()
     }
 }
 
+inline vec3 random_in_unit_sphere_r(unsigned int &seed)
+{
+    while (true)
+    {
+        auto p = vec3::random_r(-1, 1, seed);
+        if (p.length_squared() >= 1) continue;
+        return p;
+    }
+}
+
 inline vec3 random_unit_vector()
 {
     return unit_vector(random_in_unit_sphere());
 }
 
+inline vec3 random_unit_vector_r(unsigned int &seed)
+{
+    return unit_vector(random_in_unit_sphere_r(seed));
+}
+
 inline vec3 random_in_hemisphere(const vec3 &normal)
 {
     vec3 in_unit_sphere = random_in_unit_sphere();
+    if (dot(in_unit_sphere, normal) >
+        0.0)  // In the same hemisphere as the normal
+        return in_unit_sphere;
+    else
+        return -in_unit_sphere;
+}
+
+inline vec3 random_in_hemisphere_r(const vec3 &normal, unsigned int &seed)
+{
+    vec3 in_unit_sphere = random_in_unit_sphere_r(seed);
     if (dot(in_unit_sphere, normal) >
         0.0)  // In the same hemisphere as the normal
         return in_unit_sphere;

--- a/openmp/include/common/vec3.h
+++ b/openmp/include/common/vec3.h
@@ -78,15 +78,15 @@ class vec3
 
     inline static vec3 random_r(unsigned int &seed)
     {
-        return vec3(random_double_r(&seed), random_double_r(&seed),
-                    random_double_r(&seed));
+        return vec3(random_double_r(seed), random_double_r(seed),
+                    random_double_r(seed));
     }
 
     inline static vec3 random_r(double min, double max, unsigned int &seed)
     {
-        return vec3(random_double_r(min, max, &seed),
-                    random_double_r(min, max, &seed),
-                    random_double_r(min, max, &seed));
+        return vec3(random_double_r(min, max, seed),
+                    random_double_r(min, max, seed),
+                    random_double_r(min, max, seed));
     }
 
    public:
@@ -156,8 +156,8 @@ inline vec3 random_in_unit_disk_r(unsigned int &seed)
 {
     while (true)
     {
-        auto p = vec3(random_double_r(-1, 1, &seed),
-                      random_double_r(-1, 1, &seed), 0);
+        auto p =
+            vec3(random_double_r(-1, 1, seed), random_double_r(-1, 1, seed), 0);
         if (p.length_squared() >= 1) continue;
         return p;
     }

--- a/openmp/src/main.cc
+++ b/openmp/src/main.cc
@@ -22,7 +22,8 @@
 #include "rtweekend.h"
 #include "sphere.h"
 
-color ray_color(const ray& r, const hittable& world, int depth, unsigned int *seed)
+color ray_color(const ray& r, const hittable& world, int depth,
+                unsigned int* seed)
 {
     hit_record rec;
 

--- a/openmp/src/main.cc
+++ b/openmp/src/main.cc
@@ -23,7 +23,7 @@
 #include "sphere.h"
 
 color ray_color(const ray& r, const hittable& world, int depth,
-                unsigned int* seed)
+                unsigned int& seed)
 {
     hit_record rec;
 
@@ -34,7 +34,7 @@ color ray_color(const ray& r, const hittable& world, int depth,
     {
         ray scattered;
         color attenuation;
-        if (rec.mat_ptr->scatter(r, rec, attenuation, scattered, *seed))
+        if (rec.mat_ptr->scatter(r, rec, attenuation, scattered, seed))
             return attenuation * ray_color(scattered, world, depth - 1, seed);
         return color(0, 0, 0);
     }
@@ -140,10 +140,10 @@ int main()
             color pixel_color(0, 0, 0);
             for (int s = 0; s < samples_per_pixel; ++s)
             {
-                auto u = (i + random_double_r(&seed)) / (image_width - 1);
-                auto v = (j + random_double_r(&seed)) / (image_height - 1);
+                auto u = (i + random_double_r(seed)) / (image_width - 1);
+                auto v = (j + random_double_r(seed)) / (image_height - 1);
                 ray r = cam.get_ray_r(u, v, seed);
-                pixel_color += ray_color(r, world, max_depth, &seed);
+                pixel_color += ray_color(r, world, max_depth, seed);
             }
 
             int index = j * image_width + i;

--- a/openmp/src/main.cc
+++ b/openmp/src/main.cc
@@ -107,6 +107,7 @@ int main()
 {
     // Image
 
+    unsigned int seed = 5222;
     const auto aspect_ratio = 16.0 / 9.0;
     const int image_width = 1200;
     const int image_height = static_cast<int>(image_width / aspect_ratio);
@@ -115,6 +116,7 @@ int main()
 
     // World
 
+    srand(seed);
     auto world = random_scene();
 
     // Camera
@@ -131,12 +133,11 @@ int main()
     // Render
 
     std::vector<color> image(image_width * image_height);
-#pragma omp parallel for collapse(2)
+#pragma omp parallel for collapse(2) firstprivate(seed)
     for (int j = 0; j < image_height; j++)
     {
         for (int i = 0; i < image_width; i++)
         {
-            auto seed = unsigned(time(NULL) ^ omp_get_thread_num());
             color pixel_color(0, 0, 0);
             for (int s = 0; s < samples_per_pixel; ++s)
             {

--- a/openmp/src/main.cc
+++ b/openmp/src/main.cc
@@ -133,7 +133,7 @@ int main()
     // Render
 
     std::vector<color> image(image_width * image_height);
-#pragma omp parallel for collapse(2) firstprivate(seed)
+#pragma omp parallel for schedule(static, 1) firstprivate(seed)
     for (int j = 0; j < image_height; j++)
     {
         for (int i = 0; i < image_width; i++)

--- a/openmp/src/main.cc
+++ b/openmp/src/main.cc
@@ -34,7 +34,7 @@ color ray_color(const ray& r, const hittable& world, int depth,
     {
         ray scattered;
         color attenuation;
-        if (rec.mat_ptr->scatter(r, rec, attenuation, scattered))
+        if (rec.mat_ptr->scatter(r, rec, attenuation, scattered, *seed))
             return attenuation * ray_color(scattered, world, depth - 1, seed);
         return color(0, 0, 0);
     }
@@ -142,7 +142,7 @@ int main()
             {
                 auto u = (i + random_double_r(&seed)) / (image_width - 1);
                 auto v = (j + random_double_r(&seed)) / (image_height - 1);
-                ray r = cam.get_ray(u, v);
+                ray r = cam.get_ray_r(u, v, seed);
                 pixel_color += ray_color(r, world, max_depth, &seed);
             }
 

--- a/scripts/benchmark_omp.sh
+++ b/scripts/benchmark_omp.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-hyperfine -w 3 -r 5 -P threads 1 10 -D 2 --sort=command --shell=bash "OMP_NUM_THREADS={threads} taskset -c 0-9,20-29 ./build/openmp/OMPInOneWeekend"
+hyperfine -w 3 -r 5 -P threads 1 16 -D 2 --sort=command --shell=bash "OMP_NUM_THREADS={threads} taskset -c 0-9,20-29 ./build/openmp/OMPInOneWeekend"
+# hyperfine -w 3 -r 5 -P threads 1 16 -D 2 --sort=command --shell=bash "OMP_NUM_THREADS={threads} taskset -c 10-19,30-39 ./build/openmp/OMPInOneWeekend"

--- a/scripts/benchmark_omp.sh
+++ b/scripts/benchmark_omp.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+hyperfine -w 3 -r 5 -P threads 1 10 --sort=command --shell=bash "OMP_NUM_THREADS={threads} taskset -c 0-9,20-29 ./build/openmp/OMPInOneWeekend"

--- a/scripts/benchmark_omp.sh
+++ b/scripts/benchmark_omp.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-hyperfine -w 3 -r 5 -P threads 1 10 --sort=command --shell=bash "OMP_NUM_THREADS={threads} taskset -c 0-9,20-29 ./build/openmp/OMPInOneWeekend"
+hyperfine -w 3 -r 5 -P threads 1 10 -D 2 --sort=command --shell=bash "OMP_NUM_THREADS={threads} taskset -c 0-9,20-29 ./build/openmp/OMPInOneWeekend"

--- a/serial/src/main.cc
+++ b/serial/src/main.cc
@@ -103,6 +103,7 @@ int main()
 {
     // Image
 
+    unsigned int seed = 5222;
     const auto aspect_ratio = 16.0 / 9.0;
     const int image_width = 1200;
     const int image_height = static_cast<int>(image_width / aspect_ratio);
@@ -111,6 +112,7 @@ int main()
 
     // World
 
+    srand(seed);
     auto world = random_scene();
 
     // Camera


### PR DESCRIPTION
- Add benchmark script for OMP version
- Comment out the incorrect reduction parallization
- Set benchmark parameter step to 2
- Use `rand_r` to eliminate inner state & lock
- Ignore perf recorded data
- Format codebase
- Add reentrant version of random_xxx functions of vec3
- Change to use the reentrant and thread-safe version of random functions
- Change the passing method of seed from pointer to reference for modern C++
- Fix weird reflection/scatter & Set random seed explicitly to 5222
- Save current setups
